### PR TITLE
Remove the array of parameters in the super( ) sub-classes.

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,7 +88,8 @@ inquirer.prompt(employeeQuestions).then(employeeAnswers => {
                         .then(managerAnswer => {
                             console.log(managerAnswer);
                             const {officeNumber} = managerAnswer;
-                            let manager = {name, id, email, officeNumber};
+                            let manager = new Manager(name, id, email, officeNumber);
+                            // let manager = {name, id, email, officeNumber};
                             console.log(manager);
                         })
                         .catch(error => {
@@ -101,7 +102,8 @@ inquirer.prompt(employeeQuestions).then(employeeAnswers => {
                         .then(engineerAnswer => {
                             const {github} = engineerAnswer;
                             // console.log(engineerAnswer);
-                            let engineer = {name, id, email, github};
+                            //let engineer = {name, id, email, github};
+                            let engineer = new Engineer(name, id, email, github);
                             console.log(engineer);
                         })
                         .catch(error => {
@@ -114,7 +116,8 @@ inquirer.prompt(employeeQuestions).then(employeeAnswers => {
                         .then(internAnswer => {
                             console.log(internAnswer);
                             const {school} = internAnswer;
-                            let intern = {name, id, email, school};
+                            let intern = new Intern(name, id, email, school);
+                            //let intern = {name, id, email, school};
                             console.log(intern);
                         })
                         .catch(error => {

--- a/lib/Engineer.js
+++ b/lib/Engineer.js
@@ -2,7 +2,7 @@
 var Employee = require("./Employee");
 class Engineer extends Employee {
     constructor(name, id, email, github) {
-      super([name, id, email]); // calls super class constructor and pass in parameters
+      super(name, id, email); // calls super class constructor and pass in parameters
       this.github = github;
     }
     getGithub(){

--- a/lib/Intern.js
+++ b/lib/Intern.js
@@ -2,7 +2,7 @@
 var Employee = require("./Employee");
 class Intern extends Employee {
     constructor(name, id, email, school) {
-      super([name, id, email]); // calls super class constructor and pass in parameters
+      super(name, id, email); // calls super class constructor and pass in parameters
       this.school = school;
     }
     getSchool() {

--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -2,7 +2,7 @@
 var Employee = require("./Employee");
 class Manager extends Employee {
     constructor(name, id, email, officeNumber) {
-      super([name, id, email]); // calls super class constructor and pass in parameters
+      super(name, id, email); // calls super class constructor and pass in parameters
       this.officeNumber = officeNumber;
     }
     getOfficeNumber(){


### PR DESCRIPTION
I fixed an issue with super() in all the subclasses that passed all the tests but it was wrong. I initially set up an array of arguments as specified in MDN:
super([arguments]); // calls the parent constructor.
The problem was that when calling the constructor with the new keyword to create a new object, all the arguments were placed in an array in the first key and the other keys remained undefined.
I removed the array of arguments in super( ) and just passed the individual arguments. The tests did not pick up this error. Now it is working perfectly.